### PR TITLE
feat(integration-redefine-password): Redefine Password Flow and Register Adjustments

### DIFF
--- a/client/src/app/redefine-password/new-password/page.tsx
+++ b/client/src/app/redefine-password/new-password/page.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import React, { useState } from "react";
+import api from "../../../services/api";
+import { Header } from "components";
+import { Button } from "../../../components/ui/button";
+import { Input } from "../../../components/ui/input";
+import { Label } from "../../../components/ui/label";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Eye, EyeOff } from "lucide-react"; 
+
+export default function RedefinePassword() {
+    const router = useRouter();
+    const searchParams = useSearchParams();
+    const email = searchParams.get("email") || "";
+    const [newPassword, setNewPassword] = useState("");
+    const [confirmNewPassword, setConfirmNewPassword] = useState("");
+    const [newPasswordVisible, setNewPasswordVisible] = useState(false);
+    const [confirmNewPasswordVisible, setConfirmNewPasswordVisible] = useState(false);
+    const [isPasswordVerified, setIsPasswordVerified] = useState(true);
+    const [errorMessage, setErrorMessage] = useState("");
+
+    const toggleNewPasswordVisibility = () => {
+        setNewPasswordVisible((prev) => !prev);
+    }
+
+    const toggleConfirmNewPasswordVisibility = () => {
+        setConfirmNewPasswordVisible((prev) => !prev);
+    }
+
+    const handleUpdatePassword = async () => {
+        if (!newPassword || !confirmNewPassword) {
+            setErrorMessage("Todos os campos são obrigatórios.");
+            return;
+        }
+
+        if (newPassword !== confirmNewPassword) {
+            setErrorMessage("As novas senhas não coincidem.");
+            return;
+        }
+
+        try {
+            const updateResponse = await api.post(`/users/${email}/${newPassword}`, {});
+            if (updateResponse.status === 200) {
+                setErrorMessage("");
+                setNewPassword("");
+                setConfirmNewPassword(""); 
+                router.push("/redefine-password/success")
+            } else {
+                setErrorMessage("Falha ao alterar a senha.");
+            }
+        } catch (error) {
+            setErrorMessage("Ocorreu um erro inesperado. Por favor, tente novamente.");
+            console.error(error);
+        }
+    }
+    
+    return (
+        <div className="flex justify-center h-screen bg-gray-100 pt-24 pb-8 px-40">
+            <Header />
+            <div className="flex flex-col items-center space-y-8 p-8 w-[388px] max-h-fit rounded-xl shadow-md bg-white">
+                <div className="flex flex-col space-y-2">
+                    <h2 className="text-black font-bold text-2xl">Defina uma Nova Senha</h2>
+                    <p className="text-black text-base text-justify max-w-80 overflow-auto">
+                        Crie e confirme sua nova senha. Assegure-se de que a nova
+                        senha seja diferente da senha anterior para a sua segurança.
+                    </p>
+                </div>
+                <div className="flex flex-col space-y-2">
+                    <Label className="text-black text-base font-bold" htmlFor="Endereço de Email">Endereço de Email</Label>
+                    <div className="relative">
+                        <Input
+                            className="bg-white border-2 border-[#004BD4] w-[324px] h-[47px] rounded-[16px]"
+                            id="newPassword"
+                            type={newPasswordVisible ? "text" : "password"}
+                            placeholder="Digite sua nova senha"
+                            value={newPassword}
+                            onChange={(e) => {setNewPassword(e.target.value)}}
+                            required
+                        ></Input>
+                        <button
+                            className="absolute right-3 top-1/2 transform -translate-y-1/2"
+                            onClick={toggleNewPasswordVisibility}
+                        >
+                            {newPasswordVisible ? <Eye size={20} /> : <EyeOff size={20} />}
+                        </button>
+                    </div>
+                </div>
+                <div className="flex flex-col space-y-2">
+                    <Label className="text-black text-base font-bold" htmlFor="Endereço de Email">Confirmar Nova Senha</Label>
+                    <div className="relative">
+                        <Input
+                            className="bg-white border-2 border-[#004BD4] w-[324px] h-[47px] rounded-[16px]"
+                            id="confirmNewPassword"
+                            type={confirmNewPasswordVisible ? "text" : "password"}
+                            placeholder="Confirme sua nova senha"
+                            value={confirmNewPassword}
+                            onChange={(e) => setConfirmNewPassword(e.target.value)}
+                            required
+                        ></Input>
+                        <button
+                            className="absolute right-3 top-1/2 transform -translate-y-1/2"
+                            onClick={toggleConfirmNewPasswordVisibility}
+                        >
+                            {confirmNewPasswordVisible ? <Eye size={20} /> : <EyeOff size={20} />}
+                        </button>
+                    </div>
+                </div>
+                {errorMessage && (<p className="text-red-500 w-full text-sm mt-0">{errorMessage}</p>)}
+                <Button 
+                    className="w-full h-[47px] rounded-[24px] bg-gradient-to-r from-[#004BD4] via-[#5331CF] via-[#7726CD] to-[#A219CA]"
+                    onClick={handleUpdatePassword}
+                    disabled={!newPassword || !confirmNewPassword}
+                >Redefinir Senha</Button>
+            </div>
+        </div>
+    )
+};

--- a/client/src/app/redefine-password/new-password/page.tsx
+++ b/client/src/app/redefine-password/new-password/page.tsx
@@ -67,7 +67,7 @@ export default function RedefinePassword() {
                     </p>
                 </div>
                 <div className="flex flex-col space-y-2">
-                    <Label className="text-black text-base font-bold" htmlFor="Endereço de Email">Endereço de Email</Label>
+                    <Label className="text-black text-base font-bold" htmlFor="Endereço de Email">Nova Senha</Label>
                     <div className="relative">
                         <Input
                             className="bg-white border-2 border-[#004BD4] w-[324px] h-[47px] rounded-[16px]"

--- a/client/src/app/redefine-password/success/page.tsx
+++ b/client/src/app/redefine-password/success/page.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+import React from "react";
+import SuccessMessage from "components/successMessage";
+
+export default function RedefinePassword() {
+    return (
+        <SuccessMessage message="Parabéns! Sua senha foi atualizada com sucesso. Clique no botão abaixo para continuar para o menu principal."/>
+    )
+};

--- a/client/src/app/redefine-password/verify-email/page.tsx
+++ b/client/src/app/redefine-password/verify-email/page.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import React, { useState } from "react";
+import { Header } from "components";
+import { Button } from "../../../components/ui/button";
+import { Input } from "../../../components/ui/input";
+import { Label } from "../../../components/ui/label";
+import { verifyExistingEmail } from "validations/loginValidationSchema";
+import { useRouter } from "next/navigation";
+
+export default function RedefinePassword() {
+    const router = useRouter();
+    const [email, setEmail] = useState("");
+    const [verificationCode, setVerificationCode] = useState("");
+    const [errorMessage, setErrorMessage] = useState("");
+
+    const handleCheckEmailAndCode = async () => {
+        try {
+            const emailVerification = verifyExistingEmail(email);
+            if ((await emailVerification).success) {
+                setErrorMessage("Este endereço de email não possui cadastro.");
+                return;
+            }
+            // const codeVerification = TODO;
+                // DO WHEN VERIFICATION CODE IS IMPLEMENTED
+            // }
+            router.push(`/redefine-password/new-password?email=${encodeURIComponent(email)}`);
+
+        } catch (error) {
+            setErrorMessage("Ocorreu um erro inesperado. Por favor, tente novamente.");
+            console.error(error);
+        }
+    }
+
+    
+    return (
+        <div className="flex justify-center h-screen bg-gray-100 pt-24 pb-8 px-40">
+            <Header />
+            <div className="flex flex-col items-center space-y-8 p-8 w-[388px] max-h-fit rounded-xl shadow-md bg-white">
+                <div className="flex flex-col space-y-2">
+                    <h2 className="text-black font-bold text-2xl">Esqueci a Senha</h2>
+                    <p className="text-black text-base text-justify max-w-80 overflow-auto">
+                        Por favor, insira seu endereço de email e o código de 
+                        verificação enviado para seu email para redefinir sua senha.
+                    </p>
+                </div>
+                <div className="flex flex-col space-y-2">
+                    <Label className="text-black text-base font-bold" htmlFor="Endereço de Email">Endereço de Email</Label>
+                    <Input
+                        className="bg-white border-2 border-[#004BD4] w-[324px] h-[47px] rounded-[16px]"
+                        id="email"
+                        type="email"
+                        placeholder="email@example.com"
+                        value={email}
+                        onChange={(e) => {setEmail(e.target.value)}}
+                        required
+                    ></Input>
+                </div>
+                <div className="flex flex-col space-y-2">
+                    <Label className="text-black text-base font-bold" htmlFor="Endereço de Email">Código de Verificação</Label>
+                    <div className="flex space-x-2">
+                        <Input
+                            className="bg-white border-2 border-[#004BD4] h-[47px] rounded-[16px]"
+                            id="verificationCode"
+                            type="verificationCode"
+                            placeholder="000000"
+                            value={verificationCode}
+                            onChange={(e) => setVerificationCode(e.target.value)}
+                            required
+                        ></Input>
+                        <Button 
+                            className="m-0 h-[47px] rounded-[24px] bg-gradient-to-r from-[#004BD4] via-[#5331CF] via-[#7726CD] to-[#A219CA]"
+                            // onClick={}
+                        >
+                            Receber Código
+                        </Button>
+                    </div>
+                </div>
+                {errorMessage && (<p className="text-red-500 w-full text-sm mt-0">{errorMessage}</p>)}
+                <Button 
+                    className="w-full h-[47px] rounded-[24px] bg-gradient-to-r from-[#004BD4] via-[#5331CF] via-[#7726CD] to-[#A219CA]"
+                    onClick={handleCheckEmailAndCode}
+                    disabled={!email || !verificationCode}
+                >Continuar</Button>
+            </div>
+        </div>
+    )
+};

--- a/client/src/app/register/form/page.tsx
+++ b/client/src/app/register/form/page.tsx
@@ -1,9 +1,8 @@
 "use client"
 
-import React, { useState } from "react";
+import React from "react";
 import { Header } from "components";
-import  FormRegister  from "components/cardRegister";
-
+import  FormRegister  from "components/formRegister";
 
 export default function Register() {
 

--- a/client/src/app/register/success/page.tsx
+++ b/client/src/app/register/success/page.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+import React from "react";
+import SuccessMessage from "components/successMessage";
+
+export default function RedefinePassword() {
+    return (
+        <SuccessMessage message="Parabéns! Seu cadastro foi realizado com sucesso. Clique no botão abaixo para continuar para o menu principal."/>
+    )
+};

--- a/client/src/components/formRegister/index.tsx
+++ b/client/src/components/formRegister/index.tsx
@@ -12,7 +12,6 @@ import {
     validatePassword, 
     verifyExistingEmail, 
 } from "../../validations/loginValidationSchema";
-import { boolean, string } from "zod";
 
 const FormRegister = () => {
     const router = useRouter();
@@ -44,7 +43,7 @@ const FormRegister = () => {
             });
 
             if (response.status === 200) {
-                router.push("/chatbot");
+                router.push("/register/success");
             }
         } catch (error) {
             setErrorMessage("Um erro inesperado ocorreu. Por favor, tente novamente.");
@@ -91,14 +90,14 @@ const FormRegister = () => {
     };
 
     return (
-        <div className="flex justify-around items-center p-24">
-            <Card className="w-[400px] bg-white relative">
-                <CardHeader>
-                    <h2 className="text-black font-bold flex justify-around items-center text-2xl">
+        <div className="flex justify-center h-screen bg-gray-100 pt-24 pb-8 px-40">
+            <Card className="max-w-fit max-h-fit p-8 space-y-8 bg-white relative shadow-md border-none">
+                <CardHeader className="p-0 max-w-[324px]">
+                    <h2 className="text-black font-bold text-2xl text-center">
                         Crie Sua Conta ResumeAI!
                     </h2>
                 </CardHeader>
-                <CardContent className="overflow-auto flex flex-col gap-4 p-4 -mt-8">
+                <CardContent className="overflow-auto flex flex-col gap-4 p-0 max-w-[324px]">
                     <div className="grid gap-2 justify-center">
                         <Label className="text-black font-bold" htmlFor="Nome"> Nome </Label>
                         <Input 
@@ -207,7 +206,7 @@ const FormRegister = () => {
                     </div>
                     <div className="flex gap-2 justify-around items-center">
                         <Button 
-                            className="w-[324px] h-[47px] rounded-[24px] bg-gradient-to-r from-[#004BD4] via-[#5331CF] via-[#7726CD] to-[#A219CA]"
+                            className="w-full h-[47px] rounded-[24px] bg-gradient-to-r from-[#004BD4] via-[#5331CF] via-[#7726CD] to-[#A219CA]"
                             onClick={handleRegister}
                             disabled={!name || !last_name || !email || !password || !confirmPassword || !boxChecked}
                         > Confirmar e Continuar </Button>

--- a/client/src/components/modalLogin/index.tsx
+++ b/client/src/components/modalLogin/index.tsx
@@ -26,9 +26,14 @@ const LoginModal: React.FC<LoginModalProps> = ({ onClose }) => {
   };
 
   const goToRegister = () => {
-    router.push("/register");
+    router.push("/register/form");
     onClose();
   };
+
+  const goToRedefinePassword = () => {
+    router.push("/redefine-password/verify-email")
+    onClose();
+  }
 
   const handleLogin = async () => {
     try {
@@ -124,7 +129,8 @@ const LoginModal: React.FC<LoginModalProps> = ({ onClose }) => {
                   <p className="text-red-500 text-sm mt-0">{errorMessage}</p>
                 )}
               <div className="text-center">
-                <span className="text-black font-[Roboto] cursor-pointer hover:underline">
+                <span className="text-black font-[Roboto] cursor-pointer hover:underline"
+                  onClick={goToRedefinePassword}>
                   Esqueci minha senha
                 </span>
               </div>

--- a/client/src/components/successMessage/index.tsx
+++ b/client/src/components/successMessage/index.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { useRouter } from "next/navigation";
+import { Header } from "components";
+import { Button } from "components/ui/button";
+import { Check } from "lucide-react";
+
+interface SuccessMessageProps {
+    message: string;
+}
+
+const SuccessMessage: React.FC<SuccessMessageProps> = ({ message }) => {
+    const router = useRouter();
+
+    return (
+        <div className="flex justify-center h-screen bg-gray-100 pt-24 pb-8 px-40">
+            <Header />
+            <div className="flex flex-col items-center space-y-8 p-8 w-[388px] max-h-fit rounded-xl shadow-md bg-white">
+                <div className="flex w-24 h-24 text-white bg-green-500 rounded-full justify-center items-center">
+                    <Check className="w-12 h-12"/>
+                </div>
+                <div className="flex flex-col space-y-2 items-center">
+                    <h2 className="text-black font-bold text-2xl">Sucesso!</h2>
+                    <p className="text-black text-base text-justify max-w-80 overflow-auto">
+                        {message}
+                    </p>
+                </div>
+                <Button 
+                    className="w-full h-[47px] rounded-[24px] bg-gradient-to-r from-[#004BD4] via-[#5331CF] via-[#7726CD] to-[#A219CA]"
+                    onClick={() => router.push("/")}  
+                >Continuar</Button>
+            </div>
+        </div>
+    )
+};
+
+export default SuccessMessage;


### PR DESCRIPTION
## What I've Done:
- Created the password redefinition flow in case the user clicks on "Esqueci a Senha";
- Implemented the password redefinition flow in Front End and integrated it to the Back End;
- Created a reusable success message component, currently used after password redefinition and after user registration;
- After registration is concluded the user is to the main menu instead of the AI chatbot screen;
- Made some adjustments to register form design and aesthetic.

## How to Test It:
- Run Front End: 
  `cd client`
  `pnpm run dev`
- Run Back End:
  `cd server`
  `fastapi dev main.py`
- Click on Login button and "Esqueci a Senha".